### PR TITLE
Remove ethash to make go-ethereum hive work

### DIFF
--- a/clients/go-ethereum/Dockerfile
+++ b/clients/go-ethereum/Dockerfile
@@ -45,9 +45,4 @@ ADD genesis.json /genesis.json
 # Export the usual networking ports to allow outside access to the node
 EXPOSE 8545 8546 8547 8551 30303 30303/udp
 
-# Generate the ethash verification caches
-RUN \
- /usr/local/bin/geth makecache     1 ~/.ethereum/geth/ethash && \
- /usr/local/bin/geth makecache 30001 ~/.ethereum/geth/ethash
-
 ENTRYPOINT ["/geth.sh"]

--- a/clients/go-ethereum/geth.sh
+++ b/clients/go-ethereum/geth.sh
@@ -141,7 +141,7 @@ fi
 
 # Configure any mining operation
 if [ "$HIVE_MINER" != "" ] && [ "$HIVE_NODETYPE" != "light" ]; then
-    FLAGS="$FLAGS --mine --miner.threads 1 --miner.etherbase $HIVE_MINER"
+    FLAGS="$FLAGS --mine --miner.etherbase $HIVE_MINER"
 fi
 if [ "$HIVE_MINER_EXTRA" != "" ]; then
     FLAGS="$FLAGS --miner.extradata $HIVE_MINER_EXTRA"


### PR DESCRIPTION
Hive docker for L1 go-ethereum broken due to https://github.com/ethereum/go-ethereum/pull/27178.

Fixing by removing ethash verification cache at Dockerfile and also `miner.threads` flag in entrypoint.
