### PR TITLE
Fix op-erigon entrypoint

### DIFF
--- a/clients/op-erigon/entrypoint.sh
+++ b/clients/op-erigon/entrypoint.sh
@@ -56,5 +56,6 @@ set -u
   --no-downloader \
   --maxpeers=0 \
   --miner.gaslimit=$GAS_LIMIT \
+  --networkid=$CHAIN_ID \
   $EXTRA_FLAGS \
   "$@"

--- a/clients/op-erigon/entrypoint.sh
+++ b/clients/op-erigon/entrypoint.sh
@@ -43,8 +43,8 @@ set -u
   --datadir="$ERIGON_DATA_DIR" \
   --log.console.verbosity="$VERBOSITY" \
   --http \
-	--http.corsdomain="*" \
-	--http.vhosts="*" \
+  --http.corsdomain="*" \
+  --http.vhosts="*" \
   --http.addr=0.0.0.0 \
   --http.port=8545 \
   --http.api=admin,debug,eth,net,txpool,web3 \

--- a/clients/op-erigon/entrypoint.sh
+++ b/clients/op-erigon/entrypoint.sh
@@ -40,22 +40,21 @@ fi
 set -u
 
 /usr/local/bin/erigon \
-    --datadir="$ERIGON_DATA_DIR" \
-    --log.console.verbosity="$VERBOSITY" \
-    --http \
+  --datadir="$ERIGON_DATA_DIR" \
+  --log.console.verbosity="$VERBOSITY" \
+  --http \
 	--http.corsdomain="*" \
 	--http.vhosts="*" \
-    --http.addr=0.0.0.0 \
-    --http.port=8545 \
-    --http.api=admin,debug,eth,net,txpool,web3 \
-    --externalcl \
-    --ws \
-    --authrpc.jwtsecret="/hive/input/jwt-secret.txt" \
-    --authrpc.port=8551 \
-    --authrpc.addr=0.0.0.0 \
-    --nodiscover \
-    --no-downloader \
-    --maxpeers=0 \
-    --miner.gaslimit=$GAS_LIMIT \
-    $EXTRA_FLAGS \
-    "$@"
+  --http.addr=0.0.0.0 \
+  --http.port=8545 \
+  --http.api=admin,debug,eth,net,txpool,web3 \
+  --ws \
+  --authrpc.jwtsecret="/hive/input/jwt-secret.txt" \
+  --authrpc.port=8551 \
+  --authrpc.addr=0.0.0.0 \
+  --nodiscover \
+  --no-downloader \
+  --maxpeers=0 \
+  --miner.gaslimit=$GAS_LIMIT \
+  $EXTRA_FLAGS \
+  "$@"


### PR DESCRIPTION
- `--externalcl` flag is removed since erigon v2.43.0
- `--networkid` should be set by 902(hive devnet chain ID).
- If `externalcl` is not set before v2.43.0, `networkid` must be set to prevent running erigon's embedded consensus client for mainnet(default network).