### PR TITLE
Add Transaction Gossip Test

### DIFF
--- a/clients/op-erigon/entrypoint.sh
+++ b/clients/op-erigon/entrypoint.sh
@@ -54,7 +54,8 @@ set -u
   --authrpc.addr=0.0.0.0 \
   --nodiscover \
   --no-downloader \
-  --maxpeers=0 \
+  --maxpeers=50 \
+  --nat extip:`hostname -i` \
   --miner.gaslimit=$GAS_LIMIT \
   --networkid=$CHAIN_ID \
   $EXTRA_FLAGS \

--- a/optimism/nodes.go
+++ b/optimism/nodes.go
@@ -1,12 +1,17 @@
 package optimism
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"fmt"
+
 	"github.com/ethereum-optimism/optimism/op-node/client"
 	"github.com/ethereum-optimism/optimism/op-node/p2p"
 	"github.com/ethereum-optimism/optimism/op-node/sources"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
+	gethp2p "github.com/ethereum/go-ethereum/p2p"
+	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/hive/hivesim"
 )
 
@@ -63,6 +68,61 @@ type OpContracts struct {
 // OpL2Engine extends ELNode since it has all the same endpoints, except it is used for L2
 type OpL2Engine struct {
 	ELNode
+}
+
+// temporal extenstion of OpL2Engine
+// Direct RPC wrapper will be eventually moved to op-erigon or op-geth
+type OpL2EngineExtended struct {
+	*OpL2Engine
+}
+
+func (e *OpL2EngineExtended) NodeInfo(ctx context.Context) (*gethp2p.NodeInfo, error) {
+	var output *gethp2p.NodeInfo
+	err := e.RPC().CallContext(ctx, &output, "admin_nodeInfo")
+	return output, err
+
+}
+
+func (e *OpL2EngineExtended) Peers(ctx context.Context) (*gethp2p.PeerInfo, error) {
+	var output *gethp2p.PeerInfo
+	err := e.RPC().CallContext(ctx, &output, "admin_peers")
+	return output, err
+}
+
+func (e *OpL2EngineExtended) AddPeer(ctx context.Context, enode string) (bool, error) {
+	var output bool
+	err := e.RPC().CallContext(ctx, &output, "admin_addPeer", enode)
+	return output, err
+}
+
+// only interested in txhash for p2p testing
+// will be updated to use op-geth's RPCTransaction struct
+type RPCTransactionHash struct {
+	Hash common.Hash `json:"hash"`
+}
+
+func (e *OpL2EngineExtended) TxPoolContent(ctx context.Context) (map[string]map[string]map[string]*RPCTransactionHash, error) {
+	// only return necessary information(tx hash) for testing tx gossip
+	var output map[string]map[string]map[string]*RPCTransactionHash
+	err := e.RPC().CallContext(ctx, &output, "txpool_content")
+	return output, err
+}
+
+func (e *OpL2EngineExtended) ConnectPeer(ctx context.Context, neighbor *OpL2EngineExtended) error {
+	nodeInfo, err := neighbor.NodeInfo(ctx)
+	if err != nil {
+		return err
+	}
+	// sanity check by parsing result
+	_, err = enode.Parse(enode.ValidSchemes, nodeInfo.Enode)
+	if err != nil {
+		return err
+	}
+	_, err = e.AddPeer(ctx, nodeInfo.Enode)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 type OpNode struct {

--- a/optimism/nodes.go
+++ b/optimism/nodes.go
@@ -80,7 +80,6 @@ func (e *OpL2EngineExtended) NodeInfo(ctx context.Context) (*gethp2p.NodeInfo, e
 	var output *gethp2p.NodeInfo
 	err := e.RPC().CallContext(ctx, &output, "admin_nodeInfo")
 	return output, err
-
 }
 
 func (e *OpL2EngineExtended) Peers(ctx context.Context) (*gethp2p.PeerInfo, error) {


### PR DESCRIPTION
This PR tests tx gossiping between two L2 execution clients.

Requirement: L2 execution client must have `admin_addPeer` RPC. 
Erigon implemented `admin_addPeer` at https://github.com/testinprod-io/op-erigon/pull/54.

AddPeer released at https://github.com/testinprod-io/op-erigon/releases/tag/v2.43.0-0.1.5.

Test scenario
1. Launch two L2 execution clients.
2. Connect L2 execution clients using `admin_addPeer` RPC.
3. Craft transaction and send in to one L2 execution client.
4. Wait for some time to make sure that transaction has gossiped.
5. Inspect txpool of other L2 execution client using `txpool_content` RPC.

We do not need `op-proposer` and `op-batcher` to run this test.

I wrote wrapper functions for wrapping RPC calls at `nodes.go`. Original wrapper functions are all imported from `op-geth` or `op-node`, and currently modifying these codebases is impossible. These diff will be temporal, and eventually moved to `op-geth` or `op-erigon`. I introduced diff at `nodes.go` because these methods are not just for p2p, but for more general use.

Also, example hive logs for new test:
```
created genesis files
added eth1 node 0 of type go-ethereum: 172.17.0.4
added op-l2 0: 172.17.0.5
added op-node 0: 172.17.0.6
added op-l2 1: 172.17.0.7
added op-node 1: 172.17.0.8
waiting for nodes to come up
peering execution clients 172.17.0.5 with 172.17.0.7
sent tx to verifier, waiting for tx gossip
found gossiped transaction on sequencer
```

~~This test will fail on CI because `admin_addPeer` is not added in dockerhub docker image. Locally tested and works.
Will merge this PR after op-erigon remote docker image is updated.~~










