### PR TITLE
Add Transaction Gossip Disable Test

### DIFF
--- a/clients/op-erigon/entrypoint.sh
+++ b/clients/op-erigon/entrypoint.sh
@@ -34,6 +34,9 @@ sleep 1
 # We check for env variables that may not be bound so we need to disable `set -u` for this section.
 EXTRA_FLAGS=""
 set +u
+if [ "$HIVE_OP_EXEC_DISABLE_TX_GOSSIP" != "" ]; then
+    EXTRA_FLAGS="$EXTRA_FLAGS --rollup.disabletxpoolgossip=$HIVE_OP_EXEC_DISABLE_TX_GOSSIP"
+fi
 if [ "$HIVE_OP_GETH_SEQUENCER_HTTP" != "" ]; then
     EXTRA_FLAGS="$EXTRA_FLAGS --rollup.sequencerhttp $HIVE_OP_GETH_SEQUENCER_HTTP"
 fi

--- a/clients/op-erigon/entrypoint.sh
+++ b/clients/op-erigon/entrypoint.sh
@@ -36,6 +36,8 @@ EXTRA_FLAGS=""
 set +u
 if [ "$HIVE_OP_EXEC_DISABLE_TX_GOSSIP" != "" ]; then
     EXTRA_FLAGS="$EXTRA_FLAGS --rollup.disabletxpoolgossip=$HIVE_OP_EXEC_DISABLE_TX_GOSSIP"
+else
+    EXTRA_FLAGS="$EXTRA_FLAGS --rollup.disabletxpoolgossip=true"
 fi
 if [ "$HIVE_OP_GETH_SEQUENCER_HTTP" != "" ]; then
     EXTRA_FLAGS="$EXTRA_FLAGS --rollup.sequencerhttp $HIVE_OP_GETH_SEQUENCER_HTTP"

--- a/simulators/optimism/p2p/main.go
+++ b/simulators/optimism/p2p/main.go
@@ -63,11 +63,11 @@ func txGossipingTest(t *hivesim.T) {
 	d.AddEth1()
 	d.WaitUpEth1(0, time.Second*10)
 
-	d.AddOpL2()
+	d.AddOpL2(hivesim.Params{"HIVE_OP_EXEC_DISABLE_TX_GOSSIP": "false"})
 	d.AddOpNode(0, 0, false)
 	seqNode := d.GetOpL2Engine(0)
 
-	d.AddOpL2()
+	d.AddOpL2(hivesim.Params{"HIVE_OP_EXEC_DISABLE_TX_GOSSIP": "false"})
 	d.AddOpNode(0, 1, false)
 	verifNode := d.GetOpL2Engine(1)
 	verifClient := verifNode.EthClient()

--- a/simulators/optimism/p2p/main.go
+++ b/simulators/optimism/p2p/main.go
@@ -43,7 +43,11 @@ func main() {
 		Description: `This test verifies that tx gossiping works`,
 		Run:         func(t *hivesim.T) { txGossipingTest(t) },
 	})
-
+	suite.Add(&hivesim.TestSpec{
+		Name:        "tx gossip disabling",
+		Description: `This test verifies that tx gossip disabling works`,
+		Run:         func(t *hivesim.T) { txGossipingDisableTest(t) },
+	})
 	sim := hivesim.New()
 	hivesim.MustRunSuite(sim, suite)
 }
@@ -116,6 +120,77 @@ func txGossipingTest(t *hivesim.T) {
 		t.Fatal("transaction not gossiped", "err", err)
 	}
 	t.Log("found gossiped transaction on sequencer")
+}
+
+// txGossipingDisableTest verifies that a transaction submitted to a replica execution client
+// with tx gossiping disabled does not show up on the sequencer tx pool.
+func txGossipingDisableTest(t *hivesim.T) {
+	d := optimism.NewDevnet(t)
+	sender := d.L2Vault.GenerateKey()
+	receiver := d.L2Vault.GenerateKey()
+
+	d.InitChain(30, 4, 30, core.GenesisAlloc{sender: {Balance: big.NewInt(params.Ether)}})
+	d.AddEth1()
+	d.WaitUpEth1(0, time.Second*10)
+
+	d.AddOpL2()
+	d.AddOpNode(0, 0, false)
+
+	seqNode := d.GetOpL2Engine(0)
+
+	d.AddOpL2(hivesim.Params{"HIVE_OP_EXEC_DISABLE_TX_GOSSIP": "true"})
+	d.AddOpNode(0, 1, false)
+	verifNode := d.GetOpL2Engine(1)
+	verifClient := verifNode.EthClient()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		d.WaitUpOpL2Engine(0, time.Second*10)
+		wg.Done()
+	}()
+	go func() {
+		d.WaitUpOpL2Engine(1, time.Second*10)
+		wg.Done()
+	}()
+
+	t.Log("waiting for nodes to come up")
+	wg.Wait()
+
+	t.Logf("peering execution clients %s with %s", seqNode.IP.String(), verifNode.IP.String())
+	seqNodeExtended := &optimism.OpL2EngineExtended{OpL2Engine: seqNode}
+	verifNodeExtended := &optimism.OpL2EngineExtended{OpL2Engine: verifNode}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	require.NoError(t, seqNodeExtended.ConnectPeer(ctx, verifNodeExtended))
+
+	baseTx := types.NewTx(&types.DynamicFeeTx{
+		ChainID:   optimism.L2ChainIDBig,
+		Nonce:     0,
+		To:        &receiver,
+		Gas:       75000,
+		GasTipCap: big.NewInt(10 * params.GWei),
+		GasFeeCap: big.NewInt(20 * params.GWei),
+		Value:     big.NewInt(0.0001 * params.Ether),
+	})
+
+	tx, err := d.L2Vault.SignTransaction(sender, baseTx)
+	require.Nil(t, err)
+	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	require.NoError(t, verifClient.SendTransaction(ctx, tx))
+	t.Log("sent tx to verifier. Give some time to check tx gossiping is disabled")
+
+	<-time.After(10 * time.Second)
+
+	ctx, cancel = context.WithTimeout(context.Background(), 180*time.Second)
+	defer cancel()
+	found, err := optimism.WaitPendingTransactionFromTxPool(ctx, seqNodeExtended, sender, tx)
+	if found {
+		t.Fatal("transaction gossiped")
+	}
+	t.Log("transaction not gossiped on sequencer")
 }
 
 // txForwardingTest verifies that a transaction submitted to a replica with tx forwarding enabled shows up on the sequencer.


### PR DESCRIPTION
This PR tests tx gossip disabling between two L2 execution clients. Requires https://github.com/testinprod-io/hive/pull/9.

Fixed op-erigon client's `entrypoint.sh` to disable tx gossiping by default. This is to follow op-geth's [`entrypoint.sh`](https://github.com/ethereum-optimism/hive/blob/5aa0d8d61e1e963abf2c73e97e3e4924673e1af6/clients/op-geth/entrypoint.sh#L28) implementation.

op-geth:

```sh
EXTRA_FLAGS="--rollup.disabletxpoolgossip=true"
```

op-erigon(diff introduced in current PR): 
```sh
if [ "$HIVE_OP_EXEC_DISABLE_TX_GOSSIP" != "" ]; then
    EXTRA_FLAGS="$EXTRA_FLAGS --rollup.disabletxpoolgossip=$HIVE_OP_EXEC_DISABLE_TX_GOSSIP"
else
    EXTRA_FLAGS="$EXTRA_FLAGS --rollup.disabletxpoolgossip=true"
fi
```

Example hive logs for new test:
```
created genesis files
added eth1 node 0 of type go-ethereum: 172.17.0.4
added op-l2 0: 172.17.0.5
added op-node 0: 172.17.0.6
added op-l2 1: 172.17.0.7
added op-node 1: 172.17.0.8
waiting for nodes to come up
peering execution clients 172.17.0.5 with 172.17.0.7
sent tx to verifier. Give some time to check tx gossiping is disabled
transaction not gossiped on sequencer
sent tx to sequencer. Give some time to check tx gossiping is disabled
transaction not gossiped on validator
```

Every test will fail on CI because `--rollup.disabletxpoolgossip` is not recognized because tx gossip disable implementation(https://github.com/testinprod-io/op-erigon/pull/70) is not added in dockerhub docker image. Locally tested and works(`l1ops`, `rpc`, `p2p`). Will merge this PR after op-erigon remote docker image is updated.
