### PR TITLE
Update golang version to 1.19 while hive docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.18-alpine3.15 AS reqs
+FROM docker.io/library/golang:1.19-alpine3.15 AS reqs
 WORKDIR /app
 RUN apk add --no-cache build-base
 ADD go.mod .


### PR DESCRIPTION
Due to https://github.com/testinprod-io/hive/pull/17, required golang version to build hive docker image is 1.19.

Optimism started not to use docker build, but to git clone this repo and build at optimism monorepo CI, removing `Dockerfile` at upstream https://github.com/ethereum-optimism/hive.

We may also remove docker image based test, but to directly clone the repo and run tests.