### PR TITLE
Add db.size.limit flag to support op-erigon v2.55

### DIFF
--- a/clients/op-erigon/entrypoint.sh
+++ b/clients/op-erigon/entrypoint.sh
@@ -72,5 +72,6 @@ set -u
   --nat extip:`hostname -i` \
   --miner.gaslimit=$GAS_LIMIT \
   --networkid=$CHAIN_ID \
+  --db.size.limit=8TB \
   $EXTRA_FLAGS \
   "$@"


### PR DESCRIPTION
[Upstream erigon v2.55.0](https://github.com/ledgerwatch/erigon/releases/tag/v2.55.0) has a breaking change:

> Existing nodes whose MDBX page size equals 4kb must add --db.size.limit=8TB flag. Otherwise you will get MDBX_TOO_LARGE error. 

We have to add this flag because hive is using op-goerli pre-bedrock datadir.