### PR TITLE
Use latest release of op-node

### DIFF
--- a/clients/op-node/Dockerfile
+++ b/clients/op-node/Dockerfile
@@ -1,5 +1,4 @@
-ARG branch=develop
-FROM us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:$branch
+FROM us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:latest
 
 RUN apk add bash
 


### PR DESCRIPTION
Current `develop` branch of op-node breaks hive due to engine API incompatibility.
This PR resolves the issue by using latest stable release of op-node instead of develop branch.