### PR TITLE
Fix go-ethereum client version as v1.13.14

### DIFF
--- a/clients/go-ethereum/Dockerfile
+++ b/clients/go-ethereum/Dockerfile
@@ -4,8 +4,8 @@
 # produce a very minimalistic container that can be reused many times without
 # needing to constantly rebuild.
 
-ARG branch=latest
-FROM ethereum/client-go:$branch
+ARG version=v1.13.14
+FROM ethereum/client-go:$version
 
 RUN apk add --update bash curl jq
 


### PR DESCRIPTION
hive is broken with go v1.14 with the following error:
```
Fatal: Failed to register the Ethereum service: only PoS networks are supported, please transition old ones with Geth v1.13.x
```

We should fix the version to v1.13.x